### PR TITLE
Advertise custom voices under their file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
     - install with the `omnivoice` optional dependencies
 - Add `--local-files-only` to run the HuggingFace loader in offline mode
 - Add `--web-server` for a web UI (runs alongside the Wyoming server) to manage custom and cloned voices
+- Fix custom voices being advertised under their `dataset` name instead of their
+  file name, which made them impossible to synthesize when the two disagreed.
+  The `dataset` name is still accepted as an alias.
 
 ## 2.3.1
 

--- a/tests/test_custom_voices.py
+++ b/tests/test_custom_voices.py
@@ -1,0 +1,108 @@
+"""Tests for custom voice discovery and naming."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from wyoming_piper.__main__ import _setup_piper
+
+_MISMATCHED = "en_GB-jarvis-medium"  # config says dataset="jarvis-medium"
+_MATCHED = "en_US-custom-high"
+
+
+def _write_voice(data_dir: Path, file_name: str, dataset: Optional[str]) -> None:
+    config: Dict[str, Any] = {
+        "audio": {"sample_rate": 22050, "quality": "medium"},
+        "language": {"code": "en_GB"},
+    }
+    if dataset is not None:
+        config["dataset"] = dataset
+
+    (data_dir / f"{file_name}.onnx").touch()
+    (data_dir / f"{file_name}.onnx.json").write_text(
+        json.dumps(config), encoding="utf-8"
+    )
+
+
+@pytest.fixture(name="data_dir")
+def data_dir_fixture(tmp_path: Path) -> Path:
+    _write_voice(tmp_path, _MISMATCHED, dataset="jarvis-medium")
+    _write_voice(tmp_path, _MATCHED, dataset=_MATCHED)
+    return tmp_path
+
+
+@pytest.fixture(name="setup_result")
+def setup_result_fixture(data_dir: Path) -> "tuple[Any, Dict[str, Any]]":
+    args = argparse.Namespace(
+        backend="piper",
+        voice=_MATCHED,
+        data_dir=[str(data_dir)],
+        download_dir=str(data_dir),
+        update_voices=False,
+        no_streaming=False,
+    )
+    return _setup_piper(args)
+
+
+def _resolve(voices_info: Dict[str, Any], name: str) -> str:
+    """Resolve a requested voice name the way the event handler does."""
+    return voices_info.get(name, {}).get("key", name)
+
+
+@pytest.mark.parametrize(
+    ("file_name", "description"),
+    [
+        pytest.param(_MISMATCHED, "jarvis-medium (medium)", id="dataset_mismatch"),
+        pytest.param(_MATCHED, f"{_MATCHED} (medium)", id="dataset_match"),
+    ],
+)
+def test_custom_voice_advertised_by_file_name(
+    setup_result: "tuple[Any, Dict[str, Any]]", file_name: str, description: str
+) -> None:
+    """Custom voices are advertised under their file name, not "dataset"."""
+    wyoming_info, _voices_info = setup_result
+    voice = next(
+        (v for v in wyoming_info.tts[0].voices if v.name == file_name),
+        None,
+    )
+    assert voice is not None
+    assert voice.description == description
+
+
+def test_advertised_custom_voice_names_are_resolvable(
+    setup_result: "tuple[Any, Dict[str, Any]]", data_dir: Path
+) -> None:
+    """Every advertised custom voice name can be loaded again."""
+    wyoming_info, voices_info = setup_result
+    for name in (_MISMATCHED, _MATCHED):
+        assert (data_dir / f"{_resolve(voices_info, name)}.onnx").exists()
+
+    assert not any(v.name == "jarvis-medium" for v in wyoming_info.tts[0].voices)
+
+
+def test_dataset_name_still_accepted(
+    setup_result: "tuple[Any, Dict[str, Any]]", data_dir: Path
+) -> None:
+    """The previously advertised "dataset" name is kept as an alias."""
+    _wyoming_info, voices_info = setup_result
+    assert _resolve(voices_info, "jarvis-medium") == _MISMATCHED
+    assert (data_dir / f"{_MISMATCHED}.onnx").exists()
+
+
+def test_catalog_voice_not_shadowed_by_dataset_alias(data_dir: Path) -> None:
+    """A "dataset" alias never overrides a real catalog voice."""
+    _write_voice(data_dir, "my-copy-of-lessac", dataset="en_US-lessac-medium")
+    args = argparse.Namespace(
+        backend="piper",
+        voice=_MATCHED,
+        data_dir=[str(data_dir)],
+        download_dir=str(data_dir),
+        update_voices=False,
+        no_streaming=False,
+    )
+    _wyoming_info, voices_info = _setup_piper(args)
+
+    assert _resolve(voices_info, "en_US-lessac-medium") == "en_US-lessac-medium"

--- a/wyoming_piper/__main__.py
+++ b/wyoming_piper/__main__.py
@@ -285,28 +285,38 @@ def _setup_piper(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
         )
         with open(custom_config_path, "r", encoding="utf-8") as custom_config_file:
             custom_config = json.load(custom_config_file)
-            custom_name = custom_config.get("dataset", custom_voice_path.stem)
-            custom_quality = custom_config.get("audio", {}).get("quality")
-            if custom_quality:
-                description = f"{custom_name} ({custom_quality})"
-            else:
-                description = custom_name
 
-            lang_code = custom_config.get("language", {}).get("code")
+        dataset_name = custom_config.get("dataset", custom_voice_path.stem)
+        custom_quality = custom_config.get("audio", {}).get("quality")
+        if custom_quality:
+            description = f"{dataset_name} ({custom_quality})"
+        else:
+            description = dataset_name
+
+        lang_code = custom_config.get("language", {}).get("code")
+        if not lang_code:
+            lang_code = custom_config.get("espeak", {}).get("voice")
             if not lang_code:
-                lang_code = custom_config.get("espeak", {}).get("voice")
-                if not lang_code:
-                    lang_code = custom_voice_path.stem.split("_")[0]
+                lang_code = custom_voice_path.stem.split("_")[0]
 
-            voices.append(
-                TtsVoice(
-                    name=custom_name,
-                    description=description,
-                    version=None,
-                    attribution=Attribution(name="", url=""),
-                    installed=True,
-                    languages=[lang_code],
-                )
+        # Advertise the name that find_voice() can resolve, not the "dataset"
+        # field, which often disagrees with the file name.
+        voices.append(
+            TtsVoice(
+                name=custom_voice_name,
+                description=description,
+                version=None,
+                attribution=Attribution(name="", url=""),
+                installed=True,
+                languages=[lang_code],
+            )
+        )
+
+        if dataset_name != custom_voice_name:
+            # Older versions advertised "dataset" as the voice name, so keep
+            # accepting it from clients that stored it.
+            voices_info.setdefault(
+                dataset_name, {"_is_alias": True, "key": custom_voice_name}
             )
 
     wyoming_info = Info(


### PR DESCRIPTION
Fix for: https://github.com/home-assistant/core/issues/178560

## The problem

Custom voices are advertised using the `dataset` field of their `.onnx.json`:

```python
custom_name = custom_config.get("dataset", custom_voice_path.stem)
voices.append(TtsVoice(name=custom_name, ...))
```

But `find_voice()` only ever resolves a voice by file name (`<data_dir>/<name>.onnx`). When the two disagree, the voice a client sees cannot be synthesized, and the name that would work is never advertised.

This is the common case for community voices. Using [jgkawell/jarvis](https://huggingface.co/jgkawell/jarvis) (`"dataset": "jarvis-medium"`) renamed to the Piper naming convention:

```
name='jarvis-medium'  description='jarvis-medium (medium)'  ->  VoiceNotFoundError
```

`find_voice("jarvis-medium", ...)` raises, the handler writes an `error` event and closes the connection, and the client gets no audio at all. Reported downstream as home-assistant/core#178560, where it surfaces as an ffmpeg error on an empty stream.

## The fix

Advertise `custom_voice_name` — the name `find_voice()` already resolved successfully — and keep `dataset` for the description, so the label users see is unchanged:

```
name='en_GB-jarvis-medium'  description='jarvis-medium (medium)'  ->  loads
```

When `dataset` differs from the file name it is registered in `voices_info` as an alias (`{"_is_alias": True, "key": <file name>}`), so clients that stored the previously advertised name keep working through the existing alias resolution in `handler.py`. `setdefault` is used, so a `dataset` value that collides with a real catalog voice cannot shadow it.

## Testing

New `tests/test_custom_voices.py` covers advertised names for both the matching and mismatching case, that every advertised custom voice resolves back to a file on disk, the `dataset` alias, and the catalog-shadowing guard. Three of the five fail against `main`.

Note for anyone with a working setup: voices whose files were already named to match `dataset` are unaffected. Anyone who saved the old `dataset`-derived name in an automation now gets it resolved via the alias rather than as a first-class voice, so the client's voice list will show the file-name entry instead.