### PR TITLE
Fix the dev requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,18 @@ disallow_untyped_defs = true
 dev = [
     "black",
     "flake8",
+    "isort",
     "mypy",
     "pylint",
     "pytest",
     "pytest-asyncio",
     "build",
-    "flask>=3,<4",
+    # For tests/test_web_server.py
+    "wyoming-piper[web]",
+    # For tests/dtw.py and the MFCC comparison in tests/test_piper.py.
+    # numpy<2 has no wheels for Python 3.13, which is what CI runs on.
     "scipy>=1.10,<2",
-    "numpy>=1.20,<2",
+    "numpy>=1.26,<3",
     "python-speech-features>=0.6,<1",
 ]
 http = [

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,6 @@ minversion = 4.12.1
 description = run the tests with pytest
 package = wheel
 wheel_build_env = .pkg
-deps =
-    pytest>=7,<8
-    pytest-asyncio<1
-    scipy>=1.10.0,<2
-    numpy>=1.20,<2
-    python-speech-features==0.6
+extras = dev
 commands =
     pytest {tty:--color=yes} {posargs}


### PR DESCRIPTION
### numpy is unsatisfiable on Python 3.13

CI pins Python 3.13 and installs with `script/setup --dev`, but the `dev` extra
asked for `numpy>=1.20,<2` — and numpy has no `<2` wheels for cp313, so pip
falls back to building 1.26.4 from source:

```
numpy>=1.20.0,<=1.26.4 has no usable wheels ... your requirements are unsatisfiable
```

Bumped to `numpy>=1.26,<3`. Nothing needed the old cap: both
`python-speech-features` and `scipy` work fine under numpy 2.

### isort was missing

`script/format` and `script/lint` both run `python -m isort`, but the `dev`
extra never installed it, so neither worked in a fresh `script/setup --dev` venv.

### tox duplicated the test deps

`tox.ini` carried its own copy of the test requirements with drifting pins
(`pytest>=7,<8`, `pytest-asyncio<1`, and the same broken `numpy<2`). It now uses
`extras = dev` so there is one source of truth.

Also swapped the bare `flask>=3,<4` for `wyoming-piper[web]` so the dev extra
tracks the `web` extra rather than drifting from it — same self-reference the
`omnivoice` extra already uses.

### Testing

On a clean Python 3.13 venv from `pip install -e .[dev]`: resolves without
building anything from source, all 19 tests pass, and `isort --check` runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)